### PR TITLE
Exclude row_number for MySQL 8 since it's native

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -780,10 +780,10 @@ uninstall-am:
 
 
 load.sql:
-	sh load.sql.sh $(enable_functions) > load.sql
+	sh load.sql.sh $(MYSQL_VERSION) $(enable_functions) > load.sql
 
 unload.sql:
-	sh unload.sql.sh $(enable_functions) > unload.sql
+	sh unload.sql.sh $(MYSQL_VERSION) $(enable_functions) > unload.sql
 
 load:
 	mysql $(MYSQL_OPTIONS) < load.sql

--- a/load.sql.sh
+++ b/load.sql.sh
@@ -1,3 +1,7 @@
+mysql_version="$1"
+mysql_version_major=`expr $mysql_version : '\([[0-9]]*\)'`
+shift
+
 [ $# -eq 0 ] && enable_all=1
 enable_functions="$@"
 
@@ -17,7 +21,7 @@ create_function() {
     echo "CREATE FUNCTION $1 RETURNS $2 SONAME 'udf_infusion.so';"
 }
 
-sh unload.sql.sh
+sh unload.sql.sh $mysql_version $enable_functions
 
 if_enable "bound" && create_function "bound" "real"
 if_enable "bround" && create_function "bround" "real"
@@ -42,7 +46,7 @@ if_enable "percentile_cont" && create_agg_function "percentile_cont" "real"
 if_enable "percentile_disc" && create_agg_function "percentile_disc" "real"
 if_enable "rotbit" && create_function "rotbit" "integer"
 if_enable "rotint" && create_function "rotint" "integer"
-if_enable "row_number" && create_function "row_number" "integer"
+if_enable "row_number" && test $mysql_version_major -lt 8 && create_function "row_number" "integer"
 if_enable "rsumd" && create_function "rsumd" "real"
 if_enable "rsumi" && create_function "rsumi" "integer"
 if_enable "setbit" && create_function "setbit" "integer"

--- a/unload.sql.sh
+++ b/unload.sql.sh
@@ -1,3 +1,7 @@
+mysql_version="$1"
+mysql_version_major=`expr $mysql_version : '\([[0-9]]*\)'`
+shift
+
 [ $# -eq 0 ] && enable_all=1
 enable_functions="$@"
 
@@ -36,7 +40,7 @@ if_enable "percentile_cont" && drop_function "percentile_cont"
 if_enable "percentile_disc" && drop_function "percentile_disc"
 if_enable "rotbit" && drop_function "rotbit"
 if_enable "rotint" && drop_function "rotint"
-if_enable "row_number" && drop_function "row_number"
+if_enable "row_number" && test $mysql_version_major -lt 8 && drop_function "row_number"
 if_enable "rsumd" && drop_function "rsumd"
 if_enable "rsumi" && drop_function "rsumi"
 if_enable "setbit" && drop_function "setbit"


### PR DESCRIPTION
`row_number` is a native function in MySQL 8, so `load.sql` fails to load with:

```
ERROR 1585 (HY000) at line 55: This function 'row_number' has the same name as a native function
```

This excludes `row_number` for MySQL 8+.

It also passes `$enable_functions` to `sh unload.sql.sh` so if you use the `--enable-functions` flag, you only get `DROP EXISTS` for the functions you specify in `load.sql`.

My shell scripting isn't great, so there may be a cleaner way to do this.