### PR TITLE
Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ before installation:
 
 ## Installation of prerequisites
 
-Debian / Ubuntu
+Ubuntu
 
 ```
 apt-get install libmysqlclient-dev build-essential
+```
+
+Debian (uses MariaDB)
+
+```
+apt-get install default-libmysqlclient-dev build-essential
 ```
 
 On CentOS / Fedora

--- a/src/common.h
+++ b/src/common.h
@@ -76,7 +76,9 @@ typedef long long longlong;
 
 #if MYSQL_VERSION_ID >= 80001
 #ifdef __cplusplus
+#ifndef MARIADB_VERSION_ID
 typedef bool my_bool;
+#endif
 #else
 typedef char my_bool;
 #endif


### PR DESCRIPTION
Debian now uses MariaDB. This PR:

- Tells the user which packages are needed (`libmysqlclient-dev` doesn't exist in Debian Buster which is the newest stable)
- Fixes compilation with MariaDB by checking if `MARIADB_VERSION_ID` is available. (The MariaDB in Buster already defined `my_bool` as `char`).

My changes were tested against on Debian Buster (It works now) and Ubuntu Bionic (It kept working).